### PR TITLE
Updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GOCMD=go
+GOCMD=GO111MODULE=on go
 
 linters-install:
 	@golangci-lint --version >/dev/null 2>&1 || { \

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,13 @@
 GOCMD=go
 
 linters-install:
-	@gometalinter --version >/dev/null 2>&1 || { \
+	@golangci-lint --version >/dev/null 2>&1 || { \
 		echo "installing linting tools..."; \
-		$(GOCMD) get github.com/alecthomas/gometalinter; \
-		gometalinter --install; \
+		$(GOCMD) get github.com/golangci/golangci-lint/cmd/golangci-lint; \
 	}
 
 lint: linters-install
-	gometalinter --vendor --disable-all --enable=vet --enable=vetshadow --enable=golint --enable=megacheck --enable=ineffassign --enable=misspell --enable=errcheck --enable=goconst ./...
+	golangci-lint run
 
 test:
 	$(GOCMD) test -cover -race ./...

--- a/_examples/basic/main.go
+++ b/_examples/basic/main.go
@@ -12,15 +12,24 @@ func main() {
 	fmt.Println(err)
 	if errors.HasType(err, "Permanent") {
 		// os.Exit(1)
+		fmt.Println("it is a permanent error")
 	}
 
 	// root error
 	cause := errors.Cause(err)
-	fmt.Println(cause)
+	fmt.Println("CAUSE:", cause)
 
 	// can even still inspect the internal error
 	fmt.Println(errors.Cause(err) == io.EOF) // will extract the cause for you
 	fmt.Println(errors.Cause(cause) == io.EOF)
+
+	// and still in a switch
+	switch errors.Cause(err) {
+	case io.EOF:
+		fmt.Println("EOF error")
+	default:
+		fmt.Println("unknown error")
+	}
 }
 
 func level1(value string) error {
@@ -31,6 +40,6 @@ func level1(value string) error {
 }
 
 func level2(value string) error {
-	err := fmt.Errorf("this is an %s", "error")
+	err := io.EOF
 	return errors.Wrap(err, "failed to do something").AddTypes("Permanent").AddTags(errors.T("value", value))
 }

--- a/_examples/helpers/built-in/main.go
+++ b/_examples/helpers/built-in/main.go
@@ -5,11 +5,11 @@ import (
 	"net"
 
 	"github.com/go-playground/errors"
-	"github.com/go-playground/errors/helpers/neterrors"
+	// init function handles registration automatically
+	_ "github.com/go-playground/errors/helpers/neterrors"
 )
 
 func main() {
-	errors.RegisterHelper(neterrors.NETErrors)
 	_, err := net.ResolveIPAddr("tcp", "foo")
 	if err != nil {
 		err = errors.Wrap(err, "failed to perform operation")

--- a/_examples/helpers/custom/main.go
+++ b/_examples/helpers/custom/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/go-playground/errors"
+)
+
+func main() {
+	errors.RegisterHelper(MyCustomErrHandler)
+	_, err := net.ResolveIPAddr("tcp", "foo")
+	if err != nil {
+		err = errors.Wrap(err, "failed to perform operation")
+	}
+
+	// all that extra context, types and tags captured for free
+	// there are more helpers and you can even create your own.
+	fmt.Println(err)
+}
+
+// MyCustomErrHandler helps classify my errors
+func MyCustomErrHandler(c errors.Chain, err error) (cont bool) {
+	switch err.(type) {
+	case net.UnknownNetworkError:
+		_ = c.AddTypes("io").AddTag("additional", "details")
+		return
+		//case net.Other:
+		//	...
+		//	return
+	}
+	return true
+}

--- a/_examples/stack/main.go
+++ b/_examples/stack/main.go
@@ -3,8 +3,6 @@ package main
 import (
 	"fmt"
 
-	"strings"
-
 	"github.com/go-playground/errors"
 )
 
@@ -12,13 +10,8 @@ func main() {
 	// maybe you just want to grab a stack trace and process on your own like go-playground/log
 	// uses it to produce a stack trace log message
 	frame := errors.Stack()
-	name := fmt.Sprintf("%n", frame)
-	file := fmt.Sprintf("%+s", frame)
-	line := fmt.Sprintf("%d", frame)
-	parts := strings.Split(file, "\n\t")
-	if len(parts) > 1 {
-		file = parts[1]
-	}
+	fmt.Printf("Function: %s File: %s Line: %d\n", frame.Function(), frame.File(), frame.Line())
 
-	fmt.Printf("Name: %s File: %s Line: %s\n", name, file, line)
+	// and still have access to the underlying runtime.Frame
+	fmt.Printf("%+v\n", frame.Frame)
 }

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -1,0 +1,21 @@
+package errors
+
+import (
+	"testing"
+)
+
+func BenchmarkError(b *testing.B) {
+	err := New("base error")
+	for i := 0; i < b.N; i++ {
+		_ = err.Error()
+	}
+}
+
+func BenchmarkErrorParallel(b *testing.B) {
+	err := New("base error")
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = err.Error()
+		}
+	})
+}

--- a/chain.go
+++ b/chain.go
@@ -10,7 +10,7 @@ func T(key string, value interface{}) Tag {
 	return Tag{Key: key, Value: value}
 }
 
-// Tag contains a single key value conbination
+// Tag contains a single key value combination
 // to be attached to your error
 type Tag struct {
 	Key   string
@@ -21,7 +21,7 @@ func newLink(err error, prefix string, skipFrames int) *Link {
 	return &Link{
 		Err:    err,
 		Prefix: prefix,
-		Source: st(skipFrames),
+		Source: StackLevel(skipFrames),
 	}
 
 }
@@ -57,12 +57,12 @@ type Link struct {
 	Tags []Tag
 
 	// Source contains the name, file and lines obtained from the stack trace
-	Source string
+	Source Frame
 }
 
 // formatError prints a single Links error
 func (l *Link) formatError() string {
-	line := fmt.Sprintf("source=%s ", l.Source)
+	line := fmt.Sprintf("source=%s: %s:%d ", l.Source.Function(), l.Source.File(), l.Source.Line())
 
 	if l.Prefix != "" {
 		line += l.Prefix
@@ -114,5 +114,5 @@ func (c Chain) AddTypes(typ ...string) Chain {
 
 // Wrap adds another contextual prefix to the error chain
 func (c Chain) Wrap(prefix string) Chain {
-	return wrap(c, prefix, 0)
+	return wrap(c, prefix, 3)
 }

--- a/errors.go
+++ b/errors.go
@@ -3,6 +3,7 @@ package errors
 import (
 	"errors"
 	"fmt"
+	"reflect"
 )
 
 var (
@@ -13,37 +14,42 @@ var (
 // errors will run all registered helpers until a match is found.
 // NOTE helpers are run in the order they are added.
 func RegisterHelper(helper Helper) {
+	for i := 0; i < len(helpers); i++ {
+		if reflect.ValueOf(helpers[i]).Pointer() == reflect.ValueOf(helper).Pointer() {
+			return
+		}
+	}
 	helpers = append(helpers, helper)
 }
 
 // New creates an error with the provided text and automatically wraps it with line information.
 func New(s string) Chain {
-	return wrap(errors.New(s), "", 0)
+	return wrap(errors.New(s), "", 3)
 }
 
 // Newf creates an error with the provided text and automatically wraps it with line information.
 // it also accepts a varadic for optional message formatting.
 func Newf(format string, a ...interface{}) Chain {
-	return wrap(fmt.Errorf(format, a...), "", 0)
+	return wrap(fmt.Errorf(format, a...), "", 3)
 }
 
 // Wrap encapsulates the error, stores a contextual prefix and automatically obtains
 // a stack trace.
 func Wrap(err error, prefix string) Chain {
-	return wrap(err, prefix, 0)
+	return wrap(err, prefix, 3)
 }
 
 // Wrapf encapsulates the error, stores a contextual prefix and automatically obtains
 // a stack trace.
 // it also accepts a varadic for prefix formatting.
 func Wrapf(err error, prefix string, a ...interface{}) Chain {
-	return wrap(err, fmt.Sprintf(prefix, a...), 0)
+	return wrap(err, fmt.Sprintf(prefix, a...), 3)
 }
 
 // WrapSkipFrames is a special version of Wrap that skips extra n frames when determining error location.
 // Normally only used when wrapping the library
 func WrapSkipFrames(err error, prefix string, n uint) Chain {
-	return wrap(err, prefix, int(n))
+	return wrap(err, prefix, int(n)+3)
 }
 
 func wrap(err error, prefix string, skipFrames int) (c Chain) {

--- a/errors_test.go
+++ b/errors_test.go
@@ -59,8 +59,9 @@ func TestWrap(t *testing.T) {
 
 	for i, tt := range tests {
 		link := tt.err.current()
-		if !strings.HasSuffix(link.Source, tt.suf) || !strings.HasPrefix(link.Source, tt.pre) {
-			t.Fatalf("IDX: %d want %s<path>%s got %s", i, tt.pre, tt.suf, link.Source)
+		source := fmt.Sprintf("%s: %s:%d", link.Source.Function(), link.Source.File(), link.Source.Line())
+		if !strings.HasSuffix(source, tt.suf) || !strings.HasPrefix(source, tt.pre) {
+			t.Fatalf("IDX: %d want %s<path>%s got %s", i, tt.pre, tt.suf, source)
 		}
 	}
 }
@@ -158,8 +159,8 @@ func TestCause2(t *testing.T) {
 }
 
 func TestHelpers(t *testing.T) {
-	fn := func(w Chain, err error) (cont bool) {
-		w.AddTypes("Test").AddTags(T("test", "tag")).AddTag("foo", "bar")
+	fn := func(w Chain, _ error) (cont bool) {
+		_ = w.AddTypes("Test").AddTags(T("test", "tag")).AddTag("foo", "bar")
 		return false
 	}
 	RegisterHelper(fn)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/go-playground/errors
 
-go 1.12
+go 1.11
 
 require github.com/aws/aws-sdk-go v1.17.14

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/go-playground/errors
+
+go 1.12
+
+require github.com/aws/aws-sdk-go v1.17.14

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+github.com/aws/aws-sdk-go v1.17.14 h1:IjqZDIQoLyZ48A93BxVrZOaIGgZPRi4nXt6WQUMJplY=
+github.com/aws/aws-sdk-go v1.17.14/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/helpers.go
+++ b/helpers.go
@@ -1,6 +1,6 @@
 package errors
 
 // Helper is a function which will automatically extract Type and Tag information based on the supplied err and
-// add it to the supplied *Link error; this can be used independently or by registering using errors.REgisterHelper(...),
+// add it to the supplied *Link error; this can be used independently or by registering using errors.RegisterHelper(...),
 // which will run the registered helper every time errors.Wrap(...) is called.
 type Helper func(Chain, error) bool

--- a/helpers/awserrors/awserrors.go
+++ b/helpers/awserrors/awserrors.go
@@ -9,6 +9,10 @@ const (
 	transient = "Transient"
 )
 
+func init() {
+	errors.RegisterHelper(AWSErrors)
+}
+
 // AWSErrors helps classify io related errors
 func AWSErrors(c errors.Chain, err error) (cont bool) {
 	switch e := err.(type) {

--- a/helpers/ioerrors/ioerrors.go
+++ b/helpers/ioerrors/ioerrors.go
@@ -6,6 +6,10 @@ import (
 	"github.com/go-playground/errors"
 )
 
+func init() {
+	errors.RegisterHelper(IOErrors)
+}
+
 // IOErrors helps classify io related errors
 func IOErrors(c errors.Chain, err error) (cont bool) {
 	switch err {

--- a/helpers/neterrors/neterrors.go
+++ b/helpers/neterrors/neterrors.go
@@ -11,6 +11,10 @@ const (
 	transient = "Transient"
 )
 
+func init() {
+	errors.RegisterHelper(NETErrors)
+}
+
 // NETErrors helps classify io related errors
 func NETErrors(c errors.Chain, err error) (cont bool) {
 	switch e := err.(type) {

--- a/stack.go
+++ b/stack.go
@@ -1,158 +1,47 @@
 package errors
 
 import (
-	"fmt"
-	"io"
-	"path"
 	"runtime"
 	"strings"
 )
 
-// Copied portions from github.com/pkg/errors which is BSD2, copied to avoid pulling in dependency that would
-// cause naming conflicts and import clashes both being named 'errors'
-//
-//Copyright (c) 2015, Dave Cheney <dave@cheney.net>
-//All rights reserved.
-//
-//Redistribution and use in source and binary forms, with or without
-//modification, are permitted provided that the following conditions are met:
-//
-//* Redistributions of source code must retain the above copyright notice, this
-//list of conditions and the following disclaimer.
-//
-//* Redistributions in binary form must reproduce the above copyright notice,
-//this list of conditions and the following disclaimer in the documentation
-//and/or other materials provided with the distribution.
-//
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-//AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-//IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-//FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-//DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-//CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-//OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-// Frame represents a program counter inside a stack frame.
-type Frame uintptr
-
-// pc returns the program counter for this frame;
-// multiple frames may have the same PC value.
-func (f Frame) pc() uintptr { return uintptr(f) - 1 }
-
-// file returns the full path to the file that contains the
-// function for this Frame's pc.
-func (f Frame) file() string {
-	fn := runtime.FuncForPC(f.pc())
-	if fn == nil {
-		return "unknown"
-	}
-	file, _ := fn.FileLine(f.pc())
-	return file
+// Frame wraps a runtime.Frame to provide some helper functions while still allowing access to
+// the original runtime.Frame
+type Frame struct {
+	runtime.Frame
 }
 
-// line returns the line number of source code of the
-// function for this Frame's pc.
-func (f Frame) line() int {
-	fn := runtime.FuncForPC(f.pc())
-	if fn == nil {
-		return 0
-	}
-	_, line := fn.FileLine(f.pc())
-	return line
-}
-
-// Format formats the frame according to the fmt.Formatter interface.
-//
-//    %s    source file
-//    %d    source line
-//    %n    function name
-//    %v    equivalent to %s:%d
-//
-// Format accepts flags that alter the printing of some verbs, as follows:
-//
-//    %+s   function name and path of source file relative to the compile time
-//          GOPATH separated by \n\t (<funcname>\n\t<path>)
-//    %+v   equivalent to %+s:%d
-func (f Frame) Format(s fmt.State, verb rune) {
-	switch verb {
-	case 's':
-		switch {
-		case s.Flag('+'):
-			pc := f.pc()
-			fn := runtime.FuncForPC(pc)
-			if fn == nil {
-				_, _ = io.WriteString(s, "unknown")
-			} else {
-				file, _ := fn.FileLine(pc)
-				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
-			}
-		default:
-			_, _ = io.WriteString(s, path.Base(f.file()))
-		}
-	case 'd':
-		fmt.Fprintf(s, "%d", f.line())
-	case 'n':
-		name := runtime.FuncForPC(f.pc()).Name()
-		_, _ = io.WriteString(s, funcname(name))
-	case 'v':
-		f.Format(s, 's')
-		_, _ = io.WriteString(s, ":")
-		f.Format(s, 'd')
-	}
-}
-
-// funcname removes the path prefix component of a function's name reported by func.Name().
-func funcname(name string) string {
-	i := strings.LastIndex(name, "/")
-	name = name[i+1:]
-	i = strings.Index(name, ".")
+// File is the runtime.Frame.File stripped down to just the filename
+func (f Frame) File() string {
+	name := f.Frame.File
+	i := strings.LastIndexByte(name, '/')
 	return name[i+1:]
 }
 
-func st(skipFrames int) string {
-	s := callers()
-	f := fr(s, 3+skipFrames)
-	name := fmt.Sprintf("%n", f)
-	file := fmt.Sprintf("%+s", f)
-	line := fmt.Sprintf("%d", f)
-	parts := strings.Split(file, "\n\t")
-	if len(parts) > 1 {
-		file = parts[1]
-	}
-	return fmt.Sprintf("%s: %s:%s", name, file, line)
+// Line is the line of the runtime.Frame and exposed for convenience.
+func (f Frame) Line() int {
+	return f.Frame.Line
 }
 
-func fr(s *stack, level int) Frame {
-	f := make([]Frame, len(*s))
-	for i := 0; i < len(f); i++ {
-		f[i] = Frame((*s)[i])
-	}
-	return f[level]
-}
-
-type stack []uintptr
-
-func callers() *stack {
-	const depth = 32
-	var pcs [depth]uintptr
-	n := runtime.Callers(3, pcs[:])
-	var st stack = pcs[0:n]
-	return &st
+// Function is the runtime.Frame.Function stripped down to just the function name
+func (f Frame) Function() string {
+	name := f.Frame.Function
+	i := strings.LastIndexByte(name, '.')
+	return name[i+1:]
 }
 
 // Stack returns a stack from for parsing into a trace line
 func Stack() Frame {
-	s := callers()
-	return fr(s, 0)
+	return StackLevel(1)
 }
 
 // StackLevel returns a stack from for parsing into a trace line
 // this is primarily used by other libraries who use this package
 // internally as the level needs to be adjusted.
-func StackLevel(level int) Frame {
-	s := callers()
-	return fr(s, level)
+func StackLevel(skip int) (f Frame) {
+	var frame [3]uintptr
+	runtime.Callers(skip+2, frame[:])
+	frames := runtime.CallersFrames(frame[:])
+	f.Frame, _ = frames.Next()
+	return
 }

--- a/stack_test.go
+++ b/stack_test.go
@@ -1,34 +1,32 @@
 package errors
 
 import (
-	"fmt"
-	"strings"
 	"testing"
 )
 
 func TestStack(t *testing.T) {
 	tests := []struct {
 		file string
-		line string
-		name string
+		line int
+		fn   string
 	}{
 		{
 			file: "stack_test.go",
-			line: "23",
-			name: "TestStack",
+			line: 21,
+			fn:   "TestStack",
 		},
 	}
 
 	for i, tt := range tests {
 		frame := Stack()
-		if v := fmt.Sprintf("%n", frame); tt.name != v {
-			t.Fatalf("IDX: %d want %s got %s", i, tt.name, v)
+		if tt.fn != frame.Function() {
+			t.Fatalf("IDX: %d want %s got %s", i, tt.fn, frame.Function())
 		}
-		if v := fmt.Sprintf("%+s", frame); !strings.HasSuffix(v, tt.file) {
-			t.Fatalf("IDX: %d want %s got %s", i, tt.file, v)
+		if tt.file != frame.File() {
+			t.Fatalf("IDX: %d want %s got %s", i, tt.file, frame.File())
 		}
-		if v := fmt.Sprintf("%d", frame); tt.line != v {
-			t.Fatalf("IDX: %d want %s got %s", i, tt.line, v)
+		if tt.line != frame.Line() {
+			t.Fatalf("IDX: %d want %d got %d", i, tt.line, frame.Line())
 		}
 	}
 }


### PR DESCRIPTION
### What's new?

- Rewrote stack frame logic from scratch
- Added the ability for error helper to be registered via import alone.
- Updated error string logic for better performance
- updated to using Go modules

**NOTE: **
This is a breaking change for 2 reasons only if neither applies to you it is backward compatible.
1. If you're using the `Stack()` or `StackLevel(...)` functions the levels have changed.
2. Update to using Go modules makes it compatible with Go 1.11+