### PR TITLE
Fixed go mod issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/go-playground/errors"
+	"github.com/go-playground/errors/v5"
 )
 
 func main() {
@@ -91,7 +91,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/go-playground/errors"
+	"github.com/go-playground/errors/v5"
 )
 
 func main() {

--- a/_examples/basic/main.go
+++ b/_examples/basic/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/go-playground/errors"
+	"github.com/go-playground/errors/v5"
 )
 
 func main() {

--- a/_examples/helpers/built-in/main.go
+++ b/_examples/helpers/built-in/main.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/go-playground/errors"
+	"github.com/go-playground/errors/v5"
 	// init function handles registration automatically
-	_ "github.com/go-playground/errors/helpers/neterrors"
+	_ "github.com/go-playground/errors/v5/helpers/neterrors"
 )
 
 func main() {

--- a/_examples/helpers/custom/main.go
+++ b/_examples/helpers/custom/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/go-playground/errors"
+	"github.com/go-playground/errors/v5"
 )
 
 func main() {

--- a/_examples/stack/main.go
+++ b/_examples/stack/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	runtimeext "github.com/go-playground/pkg/runtime"
+	runtimeext "github.com/go-playground/pkg/v3/runtime"
 )
 
 func main() {

--- a/chain.go
+++ b/chain.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	runtimeext "github.com/go-playground/pkg/runtime"
+	runtimeext "github.com/go-playground/pkg/v3/runtime"
 )
 
 // T is a shortcut to make a Tag

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
-module github.com/go-playground/errors
+module github.com/go-playground/errors/v5
 
 go 1.11
 
 require (
 	github.com/aws/aws-sdk-go v1.19.28
-	github.com/go-playground/pkg v0.0.0-20190511145249-fa4bcb050f1d
+	github.com/go-playground/pkg/v3 v3.1.5
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,5 @@
 github.com/aws/aws-sdk-go v1.19.28 h1:u0KMC+Qv0YVyz8YR6mREEtslSPkdUMzXgDJFD5196O8=
 github.com/aws/aws-sdk-go v1.19.28/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/go-playground/form v3.1.4+incompatible/go.mod h1:lhcKXfTuhRtIZCIKUeJ0b5F207aeQCPbZU09ScKjwWg=
-github.com/go-playground/pkg v0.0.0-20190511145249-fa4bcb050f1d h1:dLyXECWWFoQAp49e+ayPJyTcVAVOSAEmZ/QALeOuIfg=
-github.com/go-playground/pkg v0.0.0-20190511145249-fa4bcb050f1d/go.mod h1:Wg1j+HqWLhhVIfYdaoOuBzdutBEVcqwvBxgFZRWbybk=
-github.com/go-playground/pkg v1.0.1 h1:EsBCgjDTrlaLCflFChT2Q/M4unQQS6DnBDvHTA+fVAI=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=

--- a/helpers/awserrors/awserrors.go
+++ b/helpers/awserrors/awserrors.go
@@ -2,7 +2,7 @@ package awserrors
 
 import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/go-playground/errors"
+	"github.com/go-playground/errors/v5"
 )
 
 const (

--- a/helpers/ioerrors/ioerrors.go
+++ b/helpers/ioerrors/ioerrors.go
@@ -3,7 +3,7 @@ package ioerrors
 import (
 	"io"
 
-	"github.com/go-playground/errors"
+	"github.com/go-playground/errors/v5"
 )
 
 func init() {

--- a/helpers/neterrors/neterrors.go
+++ b/helpers/neterrors/neterrors.go
@@ -3,7 +3,7 @@ package neterrors
 import (
 	"net"
 
-	"github.com/go-playground/errors"
+	"github.com/go-playground/errors/v5"
 )
 
 const (


### PR DESCRIPTION
Go mod implementation needed to be updated to work properly. This most likely will not build properly until go-playground/pkg#2 gets pulled in. The version for that module will likely need to be bumped as well to match.